### PR TITLE
Update Datasette URL to working deployment

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -615,8 +615,8 @@
     <script>
         // Datasette API endpoint
         // Production URL: https://unicorn-leaderboard.vercel.app/leaderboard/game_scores.json
-        // Preview URL (temporary): https://unicorn-leaderboard-pgima6xn0-james-campbells-projects-98ba50e1.vercel.app/leaderboard/game_scores.json
-        const DATASETTE_URL = 'https://unicorn-leaderboard-pgima6xn0-james-campbells-projects-98ba50e1.vercel.app/leaderboard/game_scores.json';
+        // Working deployment: https://datasette-deploy-187ro4dk1-james-campbells-projects-98ba50e1.vercel.app/leaderboard/game_scores.json
+        const DATASETTE_URL = 'https://datasette-deploy-187ro4dk1-james-campbells-projects-98ba50e1.vercel.app/leaderboard/game_scores.json';
         
         let currentFilter = 'all';
         let currentSort = 'net_worth';


### PR DESCRIPTION
- Update to datasette-deploy deployment that successfully built with Python 3.12
- Previous URL was pointing to failed deployment
- Ready once authentication protection is disabled